### PR TITLE
feat: add global keyboard shortcuts

### DIFF
--- a/src/utils/use-keyboard-shortcuts.ts
+++ b/src/utils/use-keyboard-shortcuts.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from "react";
+
+const useKeyboardShortcuts = (
+  key: string,
+  callback: () => void,
+  deps: readonly unknown[] = [],
+) => {
+  const memoizedCallback = useCallback(callback, [callback, ...deps]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === key.toLowerCase()) {
+        event.preventDefault();
+        event.stopPropagation();
+        memoizedCallback();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [key, memoizedCallback]);
+};
+
+export { useKeyboardShortcuts };


### PR DESCRIPTION
This PR adds global keyboard shortcuts to control the embedded player whether it is highlighted or not. 
In my opinion this is nicer UX when running the app on a tv or similar.

- 'space' and 'p' will toggle play
- 'right arrow' will skip the song
- 'f' will toggle fullscreen